### PR TITLE
Add config to not display on the player in first person

### DIFF
--- a/src/main/java/vazkii/neat/HealthBarRenderer.java
+++ b/src/main/java/vazkii/neat/HealthBarRenderer.java
@@ -103,6 +103,8 @@ public class HealthBarRenderer {
 					break processing;
 				if(!NeatConfig.showOnPlayers && entity instanceof EntityPlayer)
 					break processing;
+        if(!NeatConfig.showOnPlayerFirstPerson && entity == mc.thePlayer && mc.gameSettings.thirdPersonView == 0)
+          break processing;
 
 				double x = passedEntity.lastTickPosX + (passedEntity.posX - passedEntity.lastTickPosX) * partialTicks;
 				double y = passedEntity.lastTickPosY + (passedEntity.posY - passedEntity.lastTickPosY) * partialTicks;

--- a/src/main/java/vazkii/neat/NeatConfig.java
+++ b/src/main/java/vazkii/neat/NeatConfig.java
@@ -32,6 +32,7 @@ public class NeatConfig {
 	public static boolean showOnPlayers = true;
 	public static boolean showOnBosses = true;
 	public static boolean showOnlyFocused = false;
+  public static boolean showOnPlayerFirstPerson = false;
 
 	public static List<String> blacklist;
 	
@@ -67,6 +68,7 @@ public class NeatConfig {
 		showOnPlayers = loadPropBool("Display on Players", showOnPlayers);
 		showOnBosses = loadPropBool("Display on Bosses", showOnBosses);
 		showOnlyFocused = loadPropBool("Only show the health bar for the entity looked at", showOnlyFocused);
+    showOnPlayerFirstPerson = loadPropBool("Display on player in first person", showOnPlayerFirstPerson);
 
 		Property prop = config.get(Configuration.CATEGORY_GENERAL, "Blacklist", new String[] { "Shulker" });
 		blacklist = Arrays.asList(prop.getStringList());


### PR DESCRIPTION
The player health bar was getting in the way when climbing up ladders and breaking blocks above my head.  So this turns it off by default when in first person, but adds a config to turn it back on.